### PR TITLE
Simpler constructors

### DIFF
--- a/src/physical.jl
+++ b/src/physical.jl
@@ -1,43 +1,22 @@
 import MobergIO: Moberg, DigitalOut, DigitalIn, AnalogOut, AnalogIn, EncoderIn
- 
-struct FurutaPendulum <: PhysicalProcess
-    # Connections
-    energy_limited::DigitalIn
-    calibrate::DigitalOut
-    system_reset::DigitalOut
-    base_encoder::EncoderIn
-    arm_encoder::EncoderIn
-    base_angle::AnalogIn
-    arm_angle::AnalogIn
-    base_velocity::AnalogIn
-    arm_velocity::AnalogIn
-    total_energy::AnalogIn
-    base_energy::AnalogIn
-    arm_energy::AnalogIn
-    d_current::AnalogIn
-    q_current::AnalogIn
-    torque::AnalogOut # Uses internal FOC controller which does not work well
-    voltage::AnalogOut
+  
+Base.@kwdef struct FurutaPendulum <: PhysicalProcess
+    m::Moberg                   = Moberg()
+    energy_limited::DigitalIn   = DigitalIn(m, Unsigned(40))
+    calibrate::DigitalOut       = DigitalOut(m, Unsigned(40))
+    system_reset::DigitalOut    = DigitalOut(m, Unsigned(41))
+    base_encoder::EncoderIn     = EncoderIn(m, Unsigned(40))
+    arm_encoder::EncoderIn      = EncoderIn(m, Unsigned(41))
+    base_angle::AnalogIn        = AnalogIn(m, Unsigned(40))
+    arm_angle::AnalogIn         = AnalogIn(m, Unsigned(41))
+    base_velocity::AnalogIn     = AnalogIn(m, Unsigned(42))
+    arm_velocity::AnalogIn      = AnalogIn(m, Unsigned(43))
+    total_energy::AnalogIn      = AnalogIn(m, Unsigned(44))
+    base_energy::AnalogIn       = AnalogIn(m, Unsigned(45))
+    arm_energy::AnalogIn        = AnalogIn(m, Unsigned(46))
+    d_current::AnalogIn         = AnalogIn(m, Unsigned(47))
+    q_current::AnalogIn         = AnalogIn(m, Unsigned(48))
+    torque::AnalogOut           = AnalogOut(m, Unsigned(40))  # Uses internal FOC controller which does not work well
+    voltage::AnalogOut          = AnalogOut(m, Unsigned(41))
 
-    function FurutaPendulum()
-        m = Moberg()
-        return new(
-            DigitalIn(m, Unsigned(40)),
-            DigitalOut(m, Unsigned(40)),
-            DigitalOut(m, Unsigned(41)),
-            EncoderIn(m, Unsigned(40)),
-            EncoderIn(m, Unsigned(41)),
-            AnalogIn(m, Unsigned(40)),
-            AnalogIn(m, Unsigned(41)),
-            AnalogIn(m, Unsigned(42)),
-            AnalogIn(m, Unsigned(43)),
-            AnalogIn(m, Unsigned(44)),
-            AnalogIn(m, Unsigned(45)),
-            AnalogIn(m, Unsigned(46)),
-            AnalogIn(m, Unsigned(47)),
-            AnalogIn(m, Unsigned(48)),
-            AnalogOut(m, Unsigned(40)),
-            AnalogOut(m, Unsigned(41)),
-        )
-    end
 end


### PR DESCRIPTION
I haven't tested this code, but there is a function `Base.@kwdef`` that makes it quite a bit simpler to define a type like this. It will also create kwarg version of the constructor, and we add Moberg as a field, but that mightb actually be an advantage.